### PR TITLE
Update dbt project configuration and version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,15 +1,15 @@
 name: 'seznam_sklik'
-version: '0.1.0'
+version: '0.1.1'
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [ ">=1.3.0", "<2.0.0" ]
 
 
-model-paths: ["models"]
-analysis-paths: ["analyses"]
-test-paths: ["tests"]
-seed-paths: ["seeds"]
-macro-paths: ["macros"]
-snapshot-paths: ["snapshots"]
+model-paths: [ "models" ]
+analysis-paths: [ "analyses" ]
+test-paths: [ "tests" ]
+seed-paths: [ "seeds" ]
+macro-paths: [ "macros" ]
+snapshot-paths: [ "snapshots" ]
 
 clean-targets:
   - "target"
@@ -18,7 +18,7 @@ clean-targets:
 models:
   materialized: ephemeral
   bind: false
-  transformation:
+  seznam_sklik:
     sources:
       +schema: seznam_sklik_source
       +materialized: view


### PR DESCRIPTION
- Standardize array formatting by adding spaces for readability.
- Update project version to `0.1.1`.
- Rename model configuration block from `transformation` to `seznam_sklik` to align with project structure.