### PR TITLE
Update SQL to use pre-aggregated metrics for better performance

### DIFF
--- a/models/marts/seznam_sklik__accounts.yml
+++ b/models/marts/seznam_sklik__accounts.yml
@@ -13,27 +13,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
+          format: "#,##0.00' Kč'"
+        avg_cpa:
+          label: "CPA"
+          type: number
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__ad_groups.yml
+++ b/models/marts/seznam_sklik__ad_groups.yml
@@ -14,52 +14,52 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00' Kč'"
         avg_cpv:
           label: "CPV"
           type: number
-          sql: "sum(${cost}) / sum(${views})"
+          sql:  "${total_spend} / ${total_views}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: ${total_impressions} * ${ad_position}) / ${total_impressions}
+#          format: "#,##0.00"
         view_rate:
           label: "VTR"
           type: number
-          sql: "sum(${views}) / sum(${impressions})"
+          sql: "${total_views} / ${total_impressions}"
           format: "#,##0.00%"
-        avg_win_rate:
-          label: "Avg. Win Rate"
-          type: number
-          sql: "sum(${impressions} * ${win_rate}) / sum(${impressions})"
-          format: "#,##0.00%"
+#        avg_win_rate:
+#          label: "Avg. Win Rate"
+#          type: number
+#          sql: "sum(${impressions} * ${win_rate}) / sum(${impressions})"
+#          format: "#,##0.00%"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__ads.yml
+++ b/models/marts/seznam_sklik__ads.yml
@@ -15,67 +15,67 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00' Kč'"
         avg_cpv:
           label: "CPV"
           type: number
-          sql: "sum(${cost}) / sum(${views})"
+          sql: "${total_spend} / ${total_views}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
         view_rate:
           label: "VTR"
           type: number
-          sql: "sum(${views}) / sum(${impressions})"
+          sql: "${total_views} / ${total_impressions}"
           format: "#,##0.00%"
-        impr_share:
-          label: "Impression Share"
-          type: number
-          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_rank:
-          label: "Ad Rank Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_budget:
-          label: "Budget Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_schedule:
-          label: "Schedule Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
+#        impr_share:
+#          label: "Impression Share"
+#          type: number
+#          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_rank:
+#          label: "Ad Rank Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_budget:
+#          label: "Budget Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_schedule:
+#          label: "Schedule Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__audiences.yml
+++ b/models/marts/seznam_sklik__audiences.yml
@@ -15,57 +15,57 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
-        impr_share:
-          label: "Impression Share"
-          type: number
-          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_rank:
-          label: "Ad Rank Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_budget:
-          label: "Budget Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_schedule:
-          label: "Schedule Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
+#        impr_share:
+#          label: "Impression Share"
+#          type: number
+#          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_rank:
+#          label: "Ad Rank Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_budget:
+#          label: "Budget Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_schedule:
+#          label: "Schedule Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__banners.yml
+++ b/models/marts/seznam_sklik__banners.yml
@@ -15,57 +15,57 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
-        impr_share:
-          label: "Impression Share"
-          type: number
-          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_rank:
-          label: "Ad Rank Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_budget:
-          label: "Budget Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_schedule:
-          label: "Schedule Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
+#        impr_share:
+#          label: "Impression Share"
+#          type: number
+#          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_rank:
+#          label: "Ad Rank Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_budget:
+#          label: "Budget Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_schedule:
+#          label: "Schedule Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__campaigns.yml
+++ b/models/marts/seznam_sklik__campaigns.yml
@@ -14,72 +14,72 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "sum(${cost}) * 1000 / sum(${impressions})"
+          sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00' Kč'"
         avg_cpv:
           label: "CPV"
           type: number
-          sql: "sum(${cost}) / sum(${views})"
+          sql: "${total_spend} / ${total_views}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
         view_rate:
           label: "VTR"
           type: number
-          sql: "sum(${views}) / sum(${impressions})"
+          sql: "${total_views} / ${total_impressions}"
           format: "#,##0.00%"
-        avg_win_rate:
-          label: "Avg. Win Rate"
-          type: number
-          sql: "sum(${impressions} * ${win_rate}) / sum(${impressions})"
-          format: "#,##0.00%"
-        impr_share:
-          label: "Impression Share"
-          type: number
-          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_rank:
-          label: "Ad Rank Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_budget:
-          label: "Budget Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
-        lost_is_schedule:
-          label: "Schedule Lost Impr. Share"
-          type: number
-          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
-          format: "#,##0.00%"
+#        avg_win_rate:
+#          label: "Avg. Win Rate"
+#          type: number
+#          sql: "sum(${impressions} * ${win_rate}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        impr_share:
+#          label: "Impression Share"
+#          type: number
+#          sql: "sum(${impressions} * ${impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_rank:
+#          label: "Ad Rank Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${rank_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_budget:
+#          label: "Budget Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${budget_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
+#        lost_is_schedule:
+#          label: "Schedule Lost Impr. Share"
+#          type: number
+#          sql: "sum(${impressions} * ${schedule_lost_impression_share}) / sum(${impressions})"
+#          format: "#,##0.00%"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__keywords.yml
+++ b/models/marts/seznam_sklik__keywords.yml
@@ -14,32 +14,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
         system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:

--- a/models/marts/seznam_sklik__search_terms.yml
+++ b/models/marts/seznam_sklik__search_terms.yml
@@ -8,32 +8,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "sum(${clicks}) / sum(${impressions})"
+          sql: "${total_clicks} / ${total_impressions}"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "sum(${cost}) / sum(${clicks})"
+          sql: "${total_spend} / ${total_clicks}"
           format: "#,##0.00' Kč'"
         avg_cpa:
           label: "CPA"
           type: number
-          sql: "sum(${cost}) / sum(${conversions})"
+          sql: "${total_spend} / ${total_conversions}"
           format: "#,##0.00' Kč'"
-        avg_position:
-          label: "Avg. Position"
-          type: number
-          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
-          format: "#,##0.00"
-        pno:
+#        avg_position:
+#          label: "Avg. Position"
+#          type: number
+#          sql: "sum(${impressions} * ${ad_position}) / sum(${impressions})"
+#          format: "#,##0.00"
+        system_pno:
           label: "PNO"
           type: number
-          sql: "sum(${spend_czk}) / sum(${conversions_value})"
+          sql: "${total_spend} / ${total_conversions_value}"
           format: "#,##0.00%"
-        roas:
+        system_roas:
           label: "ROAS"
           type: number
-          sql: "sum(${conversions_value}) / sum(${spend_czk})"
+          sql: "${total_conversions_value} / ${total_spend}"
           format: "#,##0.00%"
 
     columns:


### PR DESCRIPTION
```markdown
### Summary
This pull request updates the SQL logic to utilize pre-aggregated metric fields, replacing raw data aggregations for improved performance and maintainability. Unused fields, such as `avg_position`, `impr_share`, and related metrics, have been deprecated and commented out.

### Changes
- Transitioned to pre-aggregated metrics like `total_clicks` and `total_impressions`.
- Removed unused and deprecated fields to reduce redundancy.
  

```