### PR TITLE
feat: Introduce Device Dimension and Update Project Configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ env/
 venv/
 
 .idea/
+
+tmp/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'seznam_sklik'
-version: '0.1.5'
+version: '0.1.6'
 
 require-dbt-version: [ ">=1.3.0", "<2.0.0" ]
 
@@ -22,6 +22,8 @@ models:
     sources:
       +schema: seznam_sklik_source
       +materialized: view
+      base:
+        +materialized: ephemeral
     marts:
-      +schema: seznam_sklik
+      +schema: seznam_sklik_marts
       +materialized: table

--- a/macros/seznam_sklik_unpivot_device.sql
+++ b/macros/seznam_sklik_unpivot_device.sql
@@ -1,0 +1,97 @@
+{#
+Macro to unpivot device-specific columns in Seznam Sklik tables.
+
+This macro transforms columns with a device prefix (e.g., device_mobile__impressions, 
+device_desktop__impressions) into rows with device and metric columns.
+
+Args:
+    columns_to_unpivot (list of strings): List of metrics to unpivot (e.g., ['impressions', 'clicks', 'conversions']).
+                                         The macro will automatically find all device columns for these metrics.
+    device_pattern (string, optional): The pattern to identify the device part in column names. 
+                                      Defaults to 'device_'.
+    metric_separator (string, optional): The separator between device and metric in column names.
+                                        Defaults to '__'.
+    dimension_columns (list of strings, optional): Columns to include in the output as dimensions
+                                                 (e.g., date, campaign_name).
+                                                 These columns will be included in the output alongside
+                                                 the unpivoted data.
+                                                 Defaults to an empty list.
+
+Example:
+    ```sql
+    select
+        {{ seznam_sklik_unpivot_device(
+            columns_to_unpivot=['impressions', 'clicks', 'conversions'],
+            dimension_columns=['date', 'campaign_name', 'campaign_id']
+        ) }}
+    from my_table
+    ```
+
+    This will produce a result with columns: date, campaign_name, campaign_id, device, impressions, clicks, conversions
+    where device will have values like 'mobile', 'desktop', 'tablet' and the metric columns will have the corresponding values.
+#}
+{% macro seznam_sklik_unpivot_device(columns_to_unpivot, device_pattern='device_', metric_separator='__', dimension_columns=[], relation=none, column_names=none) %}
+
+-- Mobile device
+select
+    {% for dim_column in dimension_columns %}
+        {{ dim_column }},
+    {% endfor %}
+
+    'mobile' as device,
+
+    {% for metric in columns_to_unpivot %}
+        device_phone__{{ metric }} as {{ metric }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+
+from source
+
+union all
+
+-- Desktop device
+select
+    {% for dim_column in dimension_columns %}
+        {{ dim_column }},
+    {% endfor %}
+
+    'desktop' as device,
+
+    {% for metric in columns_to_unpivot %}
+        device_desktop__{{ metric }} as {{ metric }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+
+from source
+
+union all
+
+-- Tablet device
+select
+    {% for dim_column in dimension_columns %}
+        {{ dim_column }},
+    {% endfor %}
+
+    'tablet' as device,
+
+    {% for metric in columns_to_unpivot %}
+        device_tablet__{{ metric }} as {{ metric }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+
+from source
+
+union all
+
+-- Other device
+select
+    {% for dim_column in dimension_columns %}
+        {{ dim_column }},
+    {% endfor %}
+
+    'other' as device,
+
+    {% for metric in columns_to_unpivot %}
+        device_other__{{ metric }} as {{ metric }}{% if not loop.last %},{% endif %}
+    {% endfor %}
+
+from source
+
+{% endmacro %}

--- a/models/marts/seznam_sklik__ad_groups.sql
+++ b/models/marts/seznam_sklik__ad_groups.sql
@@ -1,4 +1,10 @@
-with groups_stats as (
+with groups_settings as (
+
+    select *
+    from {{ ref('source_seznam_sklik__groups_settings') }}
+),
+
+groups_stats as (
 
     select *
     from {{ ref('source_seznam_sklik__groups_stats') }}
@@ -33,18 +39,20 @@ fields as (
     select
         groups_stats.date_day,
 
-        groups_stats.account_id,
-        groups_stats.account_name,
+        groups_settings.account_id,
+        groups_settings.account_name,
 
-        groups_stats.campaign_id,
-        groups_stats.campaign_name,
+        groups_settings.campaign_id,
+        groups_settings.campaign_name,
 
         groups_stats.ad_group_id,
-        groups_stats.ad_group_name,
-        groups_stats.ad_group_status,
+        groups_settings.ad_group_name,
+        groups_settings.ad_group_status,
 
-        groups_stats.set_cpc,
-        groups_stats.set_cpm,
+        groups_settings.set_cpc,
+        groups_settings.set_cpm,
+
+        groups_stats.device,
 
         groups_stats.impressions,
         groups_stats.clicks,
@@ -63,6 +71,8 @@ fields as (
         coalesce(views_stats.view_rate_100, 0) as view_rate_100,
 
     from groups_stats
+    left join groups_settings
+        on groups_stats.ad_group_id = groups_settings.ad_group_id
     left join views_stats
         on groups_stats.ad_group_id = views_stats.ad_group_id
         and groups_stats.date_day = views_stats.date_day

--- a/models/marts/seznam_sklik__ad_groups.yml
+++ b/models/marts/seznam_sklik__ad_groups.yml
@@ -8,6 +8,7 @@ models:
           combination_of_columns:
             - ad_group_id
             - campaign_id
+            - device
             - date_day
 
     columns:

--- a/models/marts/seznam_sklik__ad_groups.yml
+++ b/models/marts/seznam_sklik__ad_groups.yml
@@ -76,6 +76,14 @@ models:
             label: "Ad Group Status"
             type: string
 
+      - name: device
+        data_type: string
+        description: "{{ doc('device') }}"
+        meta:
+          dimension:
+            label: "Device"
+            type: string
+
       - name: set_cpc
         data_type: numeric
         description: "{{ doc('set_cpc') }}"

--- a/models/marts/seznam_sklik__campaigns.sql
+++ b/models/marts/seznam_sklik__campaigns.sql
@@ -8,7 +8,6 @@ groups_stats as (
 
     select *
     from {{ ref('source_seznam_sklik__groups_stats') }}
-    where win_rate != 0
 ),
 
 ads_stats as (
@@ -24,6 +23,8 @@ campaigns_stats as (
         date_day,
 
         campaign_id,
+
+        device,
 
         sum(impressions) as impressions,
         sum(clicks) as clicks,
@@ -41,7 +42,7 @@ campaigns_stats as (
         sum(schedule_lost_impressions) as schedule_lost_impressions,
 
     from groups_stats
-    {{ dbt_utils.group_by(n=2) }}
+    {{ dbt_utils.group_by(n=3) }}
 ),
 
 views_stats as (
@@ -76,6 +77,8 @@ fields as (
 
         campaign_settings.ad_selection,
         campaign_settings.video_format,
+
+        campaigns_stats.device,
 
         campaigns_stats.impressions,
         campaigns_stats.clicks,

--- a/models/marts/seznam_sklik__campaigns.yml
+++ b/models/marts/seznam_sklik__campaigns.yml
@@ -8,6 +8,7 @@ models:
           combination_of_columns:
             - campaign_id
             - account_id
+            - device
             - date_day
 
     columns:

--- a/models/seznam_sklik__docs.md
+++ b/models/seznam_sklik__docs.md
@@ -43,3 +43,4 @@
 {% docs view_rate_75 %} Percentage of impressions where the viewer watched 75% of your video. {% enddocs %}
 {% docs view_rate_100 %} Percentage of impressions where the viewer watched all of your video. {% enddocs %}
 {% docs wallet_credit_czk %} User's credit. {% enddocs %}
+{% docs device %} Device to which metrics apply. {% enddocs %}

--- a/models/sources/_seznam_sklik__models.yml
+++ b/models/sources/_seznam_sklik__models.yml
@@ -5,6 +5,7 @@ models:
   - name: source_seznam_sklik__ads_stats
   - name: source_seznam_sklik__banners_stats
   - name: source_seznam_sklik__campaigns_settings
+  - name: source_seznam_sklik__groups_settings
   - name: source_seznam_sklik__groups_stats
   - name: source_seznam_sklik__queries_stats
   - name: source_seznam_sklik__retargeting_stats

--- a/models/sources/_seznam_sklik__sources.yml
+++ b/models/sources/_seznam_sklik__sources.yml
@@ -12,6 +12,7 @@ sources:
       - name: ads_stats
       - name: banners_stats
       - name: campaigns
+      - name: groups
       - name: groups_stats
       - name: queries_stats
       - name: retargeting_stats

--- a/models/sources/base/base_seznam_sklik__groups_stats.sql
+++ b/models/sources/base/base_seznam_sklik__groups_stats.sql
@@ -1,0 +1,28 @@
+with source as (
+
+    select *
+    from {{ source('seznam_sklik', 'groups_stats') }}
+)
+
+{{ seznam_sklik_unpivot_device(
+    columns_to_unpivot=['impressions', 'clicks', 'total_money', 'conversions', 'conversion_value', 'avg_pos', 'win_rate', 'miss_impressions', 'exhausted_budget', 'stopped_by_schedule', 'under_forest_threshold', 'exhausted_budget_share', 'ish', 'ish_context', 'ish_sum'],
+    dimension_columns=['date', 'account_id', 'account_name', 'campaign__id', 'campaign__name', 'id', 'name'],
+    column_names=[
+        'date', 'account_id', 'account_name', 'campaign__id', 'campaign__name', 'id', 'name',
+        'device_phone__impressions', 'device_desktop__impressions', 'device_tablet__impressions', 'device_other__impressions',
+        'device_phone__clicks', 'device_desktop__clicks', 'device_tablet__clicks', 'device_other__clicks',
+        'device_phone__total_money', 'device_desktop__total_money', 'device_tablet__total_money', 'device_other__total_money',
+        'device_phone__conversions', 'device_desktop__conversions', 'device_tablet__conversions', 'device_other__conversions',
+        'device_phone__conversion_value', 'device_desktop__conversion_value', 'device_tablet__conversion_value', 'device_other__conversion_value',
+        'device_phone__avg_pos', 'device_desktop__avg_pos', 'device_tablet__avg_pos', 'device_other__avg_pos',
+        'device_phone__win_rate', 'device_desktop__win_rate', 'device_tablet__win_rate', 'device_other__win_rate',
+        'device_phone__miss_impressions', 'device_desktop__miss_impressions', 'device_tablet__miss_impressions', 'device_other__miss_impressions',
+        'device_phone__exhausted_budget', 'device_desktop__exhausted_budget', 'device_tablet__exhausted_budget', 'device_other__exhausted_budget',
+        'device_phone__stopped_by_schedule', 'device_desktop__stopped_by_schedule', 'device_tablet__stopped_by_schedule', 'device_other__stopped_by_schedule',
+        'device_phone__under_forest_threshold', 'device_desktop__under_forest_threshold', 'device_tablet__under_forest_threshold', 'device_other__under_forest_threshold',
+        'device_phone__exhausted_budget_share', 'device_desktop__exhausted_budget_share', 'device_tablet__exhausted_budget_share', 'device_other__exhausted_budget_share',
+        'device_phone__ish', 'device_desktop__ish', 'device_tablet__ish', 'device_other__ish',
+        'device_phone__ish_context', 'device_desktop__ish_context', 'device_tablet__ish_context', 'device_other__ish_context',
+        'device_phone__ish_sum', 'device_desktop__ish_sum', 'device_tablet__ish_sum', 'device_other__ish_sum'
+    ]
+) }}

--- a/models/sources/source_seznam_sklik__accounts_settings.sql
+++ b/models/sources/source_seznam_sklik__accounts_settings.sql
@@ -1,4 +1,4 @@
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'accounts') }}
@@ -18,7 +18,7 @@ final as (
 
         wallet_credit / 100 as wallet_credit_czk
 
-    from base
+    from source
 )
 
 select * from final

--- a/models/sources/source_seznam_sklik__ads_stats.sql
+++ b/models/sources/source_seznam_sklik__ads_stats.sql
@@ -1,4 +1,4 @@
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'ads_stats') }}
@@ -45,7 +45,7 @@ final as (
         coalesce(viewership_rate__third_quartile, 0) as view_rate_75,
         coalesce(viewership_rate__complete, 0) as view_rate_100
 
-    from base
+    from source
 )
 
 select * from final

--- a/models/sources/source_seznam_sklik__banners_stats.sql
+++ b/models/sources/source_seznam_sklik__banners_stats.sql
@@ -1,4 +1,4 @@
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'banners_stats') }}
@@ -22,8 +22,8 @@ final as (
         banner_name,
         status as banner_status,
         ad_status as banner_condition,
-        cast(width as string) as width,
-        cast(height as string) as height,
+        cast(image__width as string) as width,
+        cast(image__height as string) as height,
 
         coalesce(impressions, 0) as impressions,
         coalesce(clicks, 0) as clicks,
@@ -38,7 +38,7 @@ final as (
         coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
         coalesce(stopped_by_schedule, 0) as schedule_lost_impressions,
 
-    from base
+    from source
 )
 
 select * from final

--- a/models/sources/source_seznam_sklik__campaigns_settings.sql
+++ b/models/sources/source_seznam_sklik__campaigns_settings.sql
@@ -1,4 +1,4 @@
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'campaigns') }}
@@ -26,7 +26,7 @@ final as (
         ad_selection,
         video_format
 
-    from base
+    from source
 )
 
 select * from final

--- a/models/sources/source_seznam_sklik__groups_settings.sql
+++ b/models/sources/source_seznam_sklik__groups_settings.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select *
+    from {{ source('seznam_sklik', 'groups') }}
+),
+
+final as (
+
+    select
+        account_id,
+        account_name,
+
+        cast(campaign__id as string) as campaign_id,
+        campaign__name as campaign_name,
+
+        cast(id as string) as ad_group_id,
+        name as ad_group_name,
+        status as ad_group_status,
+
+        round(coalesce(max_cpc, 0) / 100, 2) as set_cpc,
+        round(coalesce(max_cpt, 0) / 100, 2) as set_cpm,
+
+    from source
+)
+
+select * from final

--- a/models/sources/source_seznam_sklik__groups_stats.sql
+++ b/models/sources/source_seznam_sklik__groups_stats.sql
@@ -13,7 +13,7 @@ final as (
         cast(campaign__id as string) as campaign_id,
         cast(id as string) as ad_group_id,
 
-        upper(device) end as device,
+        upper(device) as device,
 
         coalesce(impressions, 0) as impressions,
         coalesce(clicks, 0) as clicks,

--- a/models/sources/source_seznam_sklik__groups_stats.sql
+++ b/models/sources/source_seznam_sklik__groups_stats.sql
@@ -1,7 +1,7 @@
 with base as (
 
     select *
-    from {{ source('seznam_sklik', 'groups_stats') }}
+    from {{ ref('base_seznam_sklik__groups_stats') }}
 ),
 
 final as (
@@ -10,17 +10,10 @@ final as (
         {{ adapter.quote('date') }} as date_day,
 
         account_id,
-        account_name,
-
         cast(campaign__id as string) as campaign_id,
-        campaign__name as campaign_name,
-
         cast(id as string) as ad_group_id,
-        name as ad_group_name,
-        status as ad_group_status,
 
-        round(coalesce(max_cpc, 0) / 100, 2) as set_cpc,
-        round(coalesce(max_cpt, 0) / 100, 2) as set_cpm,
+        upper(device) end as device,
 
         coalesce(impressions, 0) as impressions,
         coalesce(clicks, 0) as clicks,

--- a/models/sources/source_seznam_sklik__queries_stats.sql
+++ b/models/sources/source_seznam_sklik__queries_stats.sql
@@ -1,6 +1,6 @@
 {{ config(enabled=var('seznam_sklik__using_search_term_keyword_stats', True)) }}
 
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'queries_stats') }}
@@ -35,7 +35,7 @@ final as (
 
         coalesce(avg_pos, 0) as ad_position,
 
-    from base
+    from source
 )
 
 select * from final

--- a/models/sources/source_seznam_sklik__retargeting_stats.sql
+++ b/models/sources/source_seznam_sklik__retargeting_stats.sql
@@ -1,4 +1,4 @@
-with base as (
+with source as (
 
     select *
     from {{ source('seznam_sklik', 'retargeting_stats') }}
@@ -34,7 +34,7 @@ final as (
         coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
         coalesce(stopped_by_schedule, 0) as schedule_lost_impressions
 
-    from base
+    from source
 )
 
 select * from final


### PR DESCRIPTION
This pull request introduces the dimension to the `seznam_sklik__ad_groups` and `seznam_sklik__campaigns` models, enhancing the granularity of our advertising data analysis. `device`
Key changes in this PR:
- **Device Dimension:** Added as a dimension in `seznam_sklik__ad_groups` and `seznam_sklik__campaigns`. `device`
- **Syntax Correction:** Fixed a syntax issue in `upper(device)` casting within the `source_seznam_sklik__groups_stats` model.
- **Aggregation Logic:** Updated groupings in relevant models to include the new dimension. `device`
- **Dependency Adjustments:** Modified dependencies and references to correctly incorporate the dimension. `device`
- **Project Configuration Updates:**
    - Bumped the project version to `0.1.6` in . `dbt_project.yml`
    - Updated the schema for `marts` to . `seznam_sklik_marts`
    - Added ephemeral materialization configuration for `base` models.
