### PR TITLE
**feat: Simplify impression metrics and introduce unified Impression Share (ISH)** 

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'seznam_sklik'
-version: '0.1.8'
+version: '0.1.9'
 
 require-dbt-version: [ ">=1.3.0", "<2.0.0" ]
 

--- a/models/marts/seznam_sklik__accounts.yml
+++ b/models/marts/seznam_sklik__accounts.yml
@@ -14,32 +14,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
 
     columns:
@@ -127,6 +127,7 @@ models:
               label: "Avg. Conv. Value"
               type: average
               format: "#,##0.00 Kč"
+              groups: [ "atypical_metrics" ]
 
       - name: spend_czk
         data_type: numeric
@@ -143,3 +144,4 @@ models:
               label: "Avg. Daily Spend"
               type: average
               format: "#,##0.00 Kč"
+              groups: [ "atypical_metrics" ]

--- a/models/marts/seznam_sklik__ad_groups.sql
+++ b/models/marts/seznam_sklik__ad_groups.sql
@@ -62,13 +62,8 @@ fields as (
         groups_stats.spend_czk,
 
         groups_stats.ad_position,
-
+        groups_stats.ish,
         groups_stats.auction_win,
-
-        groups_stats.miss_impressions,
-        groups_stats.rank_lost_impressions,
-        groups_stats.budget_lost_impressions,
-        groups_stats.schedule_lost_impressions,
 
         coalesce(views_stats.view_rate_25, 0) as view_rate_25,
         coalesce(views_stats.view_rate_50, 0) as view_rate_50,

--- a/models/marts/seznam_sklik__ad_groups.yml
+++ b/models/marts/seznam_sklik__ad_groups.yml
@@ -293,75 +293,20 @@ models:
           dimension:
             hidden: true
 
-      - name: miss_impressions
+      - name: ish
         data_type: numeric
         description: "{{ doc('impression_share') }}"
         meta:
           dimension:
             hidden: true
           metrics:
-            total_possible_impressions:
-              label: "Total Possible Impressions"
+            weight_impression_share:
+              label: "Impression Share Weight"
               hidden: true
               type: sum
-              sql: "${impressions} + ${miss_impressions}"
+              sql: "${impressions} * ${ish}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "COALESCE(${total_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
+              sql: "COALESCE(${weight_impression_share} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: rank_lost_impressions
-        data_type: numeric
-        description: "{{ doc('rank_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_rank_lost_impressions:
-              label: "Total Rank Lost Impressions"
-              hidden: true
-              type: sum
-            rank_lost_impression_share:
-              label: "Rank Lost IS"
-              type: number
-              sql: "COALESCE(${total_rank_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: budget_lost_impressions
-        data_type: numeric
-        description: "{{ doc('budget_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_budget_lost_impressions:
-              label: "Total Budget Lost Impressions"
-              hidden: true
-              type: sum
-            budget_lost_impression_share:
-              label: "Budget Lost IS"
-              type: number
-              sql: "COALESCE(${total_budget_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: schedule_lost_impressions
-        data_type: numeric
-        description: "{{ doc('schedule_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_schedule_lost_impressions:
-              label: "Total Schedule Lost Impressions"
-              hidden: true
-              type: sum
-            schedule_lost_impression_share:
-              label: "Schedule Lost IS"
-              type: number
-              sql: "COALESCE(${total_schedule_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__ad_groups.yml
+++ b/models/marts/seznam_sklik__ad_groups.yml
@@ -23,32 +23,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
 
     columns:
@@ -234,7 +234,7 @@ models:
             avg_position:
               label: "Avg. Position"
               type: number
-              sql: "${weight_position} / ${total_impressions}"
+              sql: "COALESCE(${weight_position} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00"
             min_position:
               label: "Min. Position"
@@ -258,11 +258,12 @@ models:
               label: "Win Rate Weight"
               hidden: true
               type: sum
-              sql: "${win_rate} * ${total_impressions}"
+              sql: "${auction_win} * ${impressions}"
             win_rate:
               label: "Win Rate"
               type: number
-              sql: "${weight_win} / ${total_impressions}"
+              sql: "COALESCE(${weight_win} / NULLIF(${total_impressions}, 0), 0)"
+              format: "#,##0.00%"
 
       - name: view_rate_25
         data_type: numeric
@@ -299,10 +300,15 @@ models:
           dimension:
             hidden: true
           metrics:
+            total_possible_impressions:
+              label: "Total Possible Impressions"
+              hidden: true
+              type: sum
+              sql: "${impressions} + ${miss_impressions}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "${total_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -320,7 +326,7 @@ models:
             rank_lost_impression_share:
               label: "Rank Lost IS"
               type: number
-              sql: "${total_rank_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_rank_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -338,7 +344,7 @@ models:
             budget_lost_impression_share:
               label: "Budget Lost IS"
               type: number
-              sql: "${total_budget_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_budget_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -356,6 +362,6 @@ models:
             schedule_lost_impression_share:
               label: "Schedule Lost IS"
               type: number
-              sql: "${total_schedule_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_schedule_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__ads.sql
+++ b/models/marts/seznam_sklik__ads.sql
@@ -33,11 +33,7 @@ fields as (
         spend_czk,
 
         ad_position,
-
-        miss_impressions,
-        rank_lost_impressions,
-        budget_lost_impressions,
-        schedule_lost_impressions,
+        ish,
 
         view_rate_25,
         view_rate_50,

--- a/models/marts/seznam_sklik__ads.yml
+++ b/models/marts/seznam_sklik__ads.yml
@@ -23,32 +23,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
 
     columns:
@@ -252,7 +252,7 @@ models:
             avg_position:
               label: "Avg. Position"
               type: number
-              sql: "${weight_position} / ${total_impressions}"
+              sql: "COALESCE(${weight_position} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00"
             min_position:
               label: "Min. Position"
@@ -300,10 +300,15 @@ models:
           dimension:
             hidden: true
           metrics:
+            total_possible_impressions:
+              label: "Total Possible Impressions"
+              hidden: true
+              type: sum
+              sql: "${impressions} + ${miss_impressions}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "${total_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -321,7 +326,7 @@ models:
             rank_lost_impression_share:
               label: "Rank Lost IS"
               type: number
-              sql: "${total_rank_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_rank_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -339,7 +344,7 @@ models:
             budget_lost_impression_share:
               label: "Budget Lost IS"
               type: number
-              sql: "${total_budget_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_budget_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]
 
@@ -357,6 +362,6 @@ models:
             schedule_lost_impression_share:
               label: "Schedule Lost IS"
               type: number
-              sql: "${total_schedule_lost_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${total_schedule_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
               format: "#,##0.00%"
               groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__ads.yml
+++ b/models/marts/seznam_sklik__ads.yml
@@ -293,75 +293,20 @@ models:
           dimension:
             hidden: true
 
-      - name: miss_impressions
+      - name: ish
         data_type: numeric
         description: "{{ doc('impression_share') }}"
         meta:
           dimension:
             hidden: true
           metrics:
-            total_possible_impressions:
-              label: "Total Possible Impressions"
+            weight_impression_share:
+              label: "Impression Share Weight"
               hidden: true
               type: sum
-              sql: "${impressions} + ${miss_impressions}"
+              sql: "${impressions} * ${ish}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "COALESCE(${total_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
+              sql: "COALESCE(${weight_impression_share} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: rank_lost_impressions
-        data_type: numeric
-        description: "{{ doc('rank_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_rank_lost_impressions:
-              label: "Total Rank Lost Impressions"
-              hidden: true
-              type: sum
-            rank_lost_impression_share:
-              label: "Rank Lost IS"
-              type: number
-              sql: "COALESCE(${total_rank_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: budget_lost_impressions
-        data_type: numeric
-        description: "{{ doc('budget_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_budget_lost_impressions:
-              label: "Total Budget Lost Impressions"
-              hidden: true
-              type: sum
-            budget_lost_impression_share:
-              label: "Budget Lost IS"
-              type: number
-              sql: "COALESCE(${total_budget_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: schedule_lost_impressions
-        data_type: numeric
-        description: "{{ doc('schedule_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_schedule_lost_impressions:
-              label: "Total Schedule Lost Impressions"
-              hidden: true
-              type: sum
-            schedule_lost_impression_share:
-              label: "Schedule Lost IS"
-              type: number
-              sql: "COALESCE(${total_schedule_lost_impressions} / NULLIF(${total_possible_impressions}, 0), 0)"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__audiences.sql
+++ b/models/marts/seznam_sklik__audiences.sql
@@ -28,11 +28,7 @@ fields as (
         spend_czk,
 
         ad_position,
-
-        miss_impressions,
-        rank_lost_impressions,
-        budget_lost_impressions,
-        schedule_lost_impressions,
+        ish,
 
     from retargeting_stats
 )

--- a/models/marts/seznam_sklik__audiences.yml
+++ b/models/marts/seznam_sklik__audiences.yml
@@ -35,7 +35,7 @@ models:
           type: number
           sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
           sql: "${total_spend} / ${total_conversions}"
@@ -227,6 +227,11 @@ models:
           dimension:
             hidden: true
           metrics:
+            total_possible_impressions:
+              label: "Total Possible Impressions"
+              hidden: true
+              type: sum
+              sql: "${impressions} + ${miss_impressions}"
             impression_share:
               label: "Impression Share"
               type: number

--- a/models/marts/seznam_sklik__audiences.yml
+++ b/models/marts/seznam_sklik__audiences.yml
@@ -220,75 +220,20 @@ models:
               format: "#,##0.00"
               groups: [ "atypical_metrics" ]
 
-      - name: miss_impressions
+      - name: ish
         data_type: numeric
         description: "{{ doc('impression_share') }}"
         meta:
           dimension:
             hidden: true
           metrics:
-            total_possible_impressions:
-              label: "Total Possible Impressions"
+            weight_impression_share:
+              label: "Impression Share Weight"
               hidden: true
               type: sum
-              sql: "${impressions} + ${miss_impressions}"
+              sql: "${impressions} * ${ish}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "${total_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${weight_impression_share} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: rank_lost_impressions
-        data_type: numeric
-        description: "{{ doc('rank_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_rank_lost_impressions:
-              label: "Total Rank Lost Impressions"
-              hidden: true
-              type: sum
-            rank_lost_impression_share:
-              label: "Rank Lost IS"
-              type: number
-              sql: "${total_rank_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: budget_lost_impressions
-        data_type: numeric
-        description: "{{ doc('budget_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_budget_lost_impressions:
-              label: "Total Budget Lost Impressions"
-              hidden: true
-              type: sum
-            budget_lost_impression_share:
-              label: "Budget Lost IS"
-              type: number
-              sql: "${total_budget_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: schedule_lost_impressions
-        data_type: numeric
-        description: "{{ doc('schedule_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_schedule_lost_impressions:
-              label: "Total Schedule Lost Impressions"
-              hidden: true
-              type: sum
-            schedule_lost_impression_share:
-              label: "Schedule Lost IS"
-              type: number
-              sql: "${total_schedule_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__banners.sql
+++ b/models/marts/seznam_sklik__banners.sql
@@ -32,11 +32,7 @@ fields as (
         spend_czk,
 
         ad_position,
-
-        miss_impressions,
-        rank_lost_impressions,
-        budget_lost_impressions,
-        schedule_lost_impressions,
+        ish,
 
     from banner_stats
 )

--- a/models/marts/seznam_sklik__banners.yml
+++ b/models/marts/seznam_sklik__banners.yml
@@ -35,7 +35,7 @@ models:
           type: number
           sql: "${total_spend} * 1000 / ${total_impressions}"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
           sql: "${total_spend} / ${total_conversions}"
@@ -259,6 +259,11 @@ models:
           dimension:
             hidden: true
           metrics:
+            total_possible_impressions:
+              label: "Total Possible Impressions"
+              hidden: true
+              type: sum
+              sql: "${impressions} + ${miss_impressions}"
             impression_share:
               label: "Impression Share"
               type: number

--- a/models/marts/seznam_sklik__banners.yml
+++ b/models/marts/seznam_sklik__banners.yml
@@ -252,75 +252,20 @@ models:
               format: "#,##0.00"
               groups: [ "atypical_metrics" ]
 
-      - name: miss_impressions
+      - name: ish
         data_type: numeric
         description: "{{ doc('impression_share') }}"
         meta:
           dimension:
             hidden: true
           metrics:
-            total_possible_impressions:
-              label: "Total Possible Impressions"
+            weight_impression_share:
+              label: "Impression Share Weight"
               hidden: true
               type: sum
-              sql: "${impressions} + ${miss_impressions}"
+              sql: "${impressions} * ${ish}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "${total_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${weight_impression_share} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: rank_lost_impressions
-        data_type: numeric
-        description: "{{ doc('rank_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_rank_lost_impressions:
-              label: "Total Rank Lost Impressions"
-              hidden: true
-              type: sum
-            rank_lost_impression_share:
-              label: "Rank Lost IS"
-              type: number
-              sql: "${total_rank_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: budget_lost_impressions
-        data_type: numeric
-        description: "{{ doc('budget_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_budget_lost_impressions:
-              label: "Total Budget Lost Impressions"
-              hidden: true
-              type: sum
-            budget_lost_impression_share:
-              label: "Budget Lost IS"
-              type: number
-              sql: "${total_budget_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: schedule_lost_impressions
-        data_type: numeric
-        description: "{{ doc('schedule_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_schedule_lost_impressions:
-              label: "Total Schedule Lost Impressions"
-              hidden: true
-              type: sum
-            schedule_lost_impression_share:
-              label: "Schedule Lost IS"
-              type: number
-              sql: "${total_schedule_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__campaigns.sql
+++ b/models/marts/seznam_sklik__campaigns.sql
@@ -33,13 +33,8 @@ campaigns_stats as (
         sum(spend_czk) as spend_czk,
 
         {{ weighted_average('ad_position', 'impressions', 'ad_position', round_to=2) }},
-
+        {{ weighted_average('ish', 'impressions', 'ish', round_to=2) }},
         {{ weighted_average('auction_win', 'impressions', 'auction_win', round_to=2) }},
-
-        sum(miss_impressions) as miss_impressions,
-        sum(rank_lost_impressions) as rank_lost_impressions,
-        sum(budget_lost_impressions) as budget_lost_impressions,
-        sum(schedule_lost_impressions) as schedule_lost_impressions,
 
     from groups_stats
     {{ dbt_utils.group_by(n=3) }}
@@ -88,18 +83,9 @@ fields as (
         campaigns_stats.spend_czk,
 
         campaigns_stats.ad_position,
-
+        coalesce(campaigns_stats.ish, 0) as ish,
         coalesce(campaigns_stats.auction_win, 0) as auction_win,
 
-        miss_impressions,
-        rank_lost_impressions,
-        budget_lost_impressions,
-        schedule_lost_impressions,
-
-        coalesce(views_stats.view_rate_25, 0) as view_rate_25,
-        coalesce(views_stats.view_rate_50, 0) as view_rate_50,
-        coalesce(views_stats.view_rate_75, 0) as view_rate_75,
-        coalesce(views_stats.view_rate_100, 0) as view_rate_100,
     from campaigns_stats
     left join views_stats
         on  campaigns_stats.campaign_id = views_stats.campaign_id

--- a/models/marts/seznam_sklik__campaigns.yml
+++ b/models/marts/seznam_sklik__campaigns.yml
@@ -50,11 +50,6 @@ models:
           type: number
           sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
-        total_possible_impressions:
-          label: "Miss Impressions Weight"
-          hidden: true
-          type: sum
-          sql: "${impressions} + ${miss_impressions}"
 
     columns:
       - name: date_day
@@ -290,75 +285,20 @@ models:
           dimension:
             hidden: true
 
-      - name: miss_impressions
+      - name: ish
         data_type: numeric
         description: "{{ doc('impression_share') }}"
         meta:
           dimension:
             hidden: true
           metrics:
-            total_possible_impressions:
-              label: "Total Possible Impressions"
+            weight_impression_share:
+              label: "Impression Share Weight"
               hidden: true
               type: sum
-              sql: "${impressions} + ${miss_impressions}"
+              sql: "${impressions} * ${ish}"
             impression_share:
               label: "Impression Share"
               type: number
-              sql: "${total_impressions} / ${total_possible_impressions}"
+              sql: "COALESCE(${weight_impression_share} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: rank_lost_impressions
-        data_type: numeric
-        description: "{{ doc('rank_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_rank_lost_impressions:
-              label: "Total Rank Lost Impressions"
-              hidden: true
-              type: sum
-            rank_lost_impression_share:
-              label: "Rank Lost IS"
-              type: number
-              sql: "${total_rank_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: budget_lost_impressions
-        data_type: numeric
-        description: "{{ doc('budget_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_budget_lost_impressions:
-              label: "Total Budget Lost Impressions"
-              hidden: true
-              type: sum
-            budget_lost_impression_share:
-              label: "Budget Lost IS"
-              type: number
-              sql: "${total_budget_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]
-
-      - name: schedule_lost_impressions
-        data_type: numeric
-        description: "{{ doc('schedule_lost_impression_share') }}"
-        meta:
-          dimension:
-            hidden: true
-          metrics:
-            total_schedule_lost_impressions:
-              label: "Total Schedule Lost Impressions"
-              hidden: true
-              type: sum
-            schedule_lost_impression_share:
-              label: "Schedule Lost IS"
-              type: number
-              sql: "${total_schedule_lost_impressions} / ${total_possible_impressions}"
-              format: "#,##0.00%"
-              groups: [ "impression_share" ]

--- a/models/marts/seznam_sklik__campaigns.yml
+++ b/models/marts/seznam_sklik__campaigns.yml
@@ -23,32 +23,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
         total_possible_impressions:
           label: "Miss Impressions Weight"
@@ -112,6 +112,14 @@ models:
         meta:
           dimension:
             label: "Campaign Status"
+            type: string
+
+      - name: device
+        data_type: string
+        description: "{{ doc('device') }}"
+        meta:
+          dimension:
+            label: "Device"
             type: string
 
       - name: ad_selection
@@ -247,11 +255,12 @@ models:
               label: "Win Rate Weight"
               hidden: true
               type: sum
-              sql: "${win_rate} * ${total_impressions}"
+              sql: "${auction_win} * ${impressions}"
             win_rate:
               label: "Win Rate"
               type: number
               sql: "${weight_win} / ${total_impressions}"
+              format: "#,##0.00%"
 
       - name: view_rate_25
         data_type: numeric
@@ -288,6 +297,11 @@ models:
           dimension:
             hidden: true
           metrics:
+            total_possible_impressions:
+              label: "Total Possible Impressions"
+              hidden: true
+              type: sum
+              sql: "${impressions} + ${miss_impressions}"
             impression_share:
               label: "Impression Share"
               type: number

--- a/models/marts/seznam_sklik__keywords.yml
+++ b/models/marts/seznam_sklik__keywords.yml
@@ -22,32 +22,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
 
     columns:
@@ -181,7 +181,7 @@ models:
             avg_position:
               label: "Avg. Position"
               type: number
-              sql: "${weight_position} / ${total_impressions}"
+              sql: "COALESCE(${weight_position} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00"
             min_position:
               label: "Min. Position"

--- a/models/marts/seznam_sklik__search_terms.yml
+++ b/models/marts/seznam_sklik__search_terms.yml
@@ -16,32 +16,32 @@ models:
         ctr:
           label: "CTR"
           type: number
-          sql: "${total_clicks} / ${total_impressions}"
+          sql: "COALESCE(${total_clicks} / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00%"
         avg_cpc:
           label: "CPC"
           type: number
-          sql: "${total_spend} / ${total_clicks}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_clicks}, 0), 0)"
           format: "#,##0.00 Kč"
         avg_cpm:
           label: "CPM"
           type: number
-          sql: "${total_spend} * 1000 / ${total_impressions}"
+          sql: "COALESCE(${total_spend} * 1000 / NULLIF(${total_impressions}, 0), 0)"
           format: "#,##0.00 Kč"
-        avg_cpa:
+        system_cpa:
           label: "CPA"
           type: number
-          sql: "${total_spend} / ${total_conversions}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions}, 0), 0)"
           format: "#,##0.00 Kč"
         system_pno:
           label: "PNO"
           type: number
-          sql: "${total_spend} / ${total_conversions_value}"
+          sql: "COALESCE(${total_spend} / NULLIF(${total_conversions_value}, 0), 0)"
           format: "#,##0.00%"
         system_roas:
           label: "ROAS"
           type: number
-          sql: "${total_conversions_value} / ${total_spend}"
+          sql: "COALESCE(${total_conversions_value} / NULLIF(${total_spend}, 0), 0)"
           format: "#,##0.00%"
 
     columns:
@@ -175,7 +175,7 @@ models:
             avg_position:
               label: "Avg. Position"
               type: number
-              sql: "${weight_position} / ${total_impressions}"
+              sql: "COALESCE(${weight_position} / NULLIF(${total_impressions}, 0), 0)"
               format: "#,##0.00"
             min_position:
               label: "Min. Position"

--- a/models/sources/source_seznam_sklik__ads_stats.sql
+++ b/models/sources/source_seznam_sklik__ads_stats.sql
@@ -32,11 +32,7 @@ final as (
         round(coalesce(total_money, 0) / 100, 2) as spend_czk,
 
         coalesce(avg_pos, 0) as ad_position,
-
-        coalesce(miss_impressions, 0) as miss_impressions,
-        coalesce(under_forest_threshold, 0) as rank_lost_impressions,
-        coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
-        coalesce(stopped_by_schedule, 0) as schedule_lost_impressions,
+        coalesce(ish_sum, 0) as ish,
 
         coalesce(skip_rate, 0) as skip_rate,
 

--- a/models/sources/source_seznam_sklik__banners_stats.sql
+++ b/models/sources/source_seznam_sklik__banners_stats.sql
@@ -32,11 +32,7 @@ final as (
         round(coalesce(total_money, 0) / 100, 2) as spend_czk,
 
         coalesce(avg_pos, 0) as ad_position,
-
-        coalesce(miss_impressions, 0) as miss_impressions,
-        coalesce(under_forest_threshold, 0) as rank_lost_impressions,
-        coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
-        coalesce(stopped_by_schedule, 0) as schedule_lost_impressions,
+        coalesce(ish_sum, 0) as ish,
 
     from source
 )

--- a/models/sources/source_seznam_sklik__groups_stats.sql
+++ b/models/sources/source_seznam_sklik__groups_stats.sql
@@ -22,13 +22,8 @@ final as (
         round(coalesce(total_money, 0) / 100, 2) as spend_czk,
 
         coalesce(avg_pos, 0) as ad_position,
-
+        coalesce(ish_sum, 0) as ish,
         coalesce(win_rate, 0) as auction_win,
-
-        coalesce(miss_impressions, 0) as miss_impressions,
-        coalesce(under_forest_threshold, 0) as rank_lost_impressions,
-        coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
-        coalesce(stopped_by_schedule, 0) as schedule_lost_impressions,
 
     from base
 )

--- a/models/sources/source_seznam_sklik__retargeting_stats.sql
+++ b/models/sources/source_seznam_sklik__retargeting_stats.sql
@@ -28,11 +28,7 @@ final as (
         round(coalesce(total_money, 0) / 100, 2) as spend_czk,
 
         coalesce(avg_pos, 0) as ad_position,
-
-        coalesce(miss_impressions, 0) as miss_impressions,
-        coalesce(under_forest_threshold, 0) as rank_lost_impressions,
-        coalesce(exhausted_budget, exhausted_budget_share, 0) as budget_lost_impressions,
-        coalesce(stopped_by_schedule, 0) as schedule_lost_impressions
+        coalesce(ish_sum, 0) as ish,
 
     from source
 )


### PR DESCRIPTION
### 🔄 **Key Changes**
- **Simplified impression metrics**: Removed granular impression loss metrics (`miss_impressions`, `rank_lost_impressions`, `budget_lost_impressions`, `schedule_lost_impressions`) to reduce complexity
- **Introduced unified ISH metric**: Added Impression Share (`ish`) as a consolidated metric for better data analysis
- **Enhanced calculation safety**: Updated division operations to use `COALESCE` with `NULLIF` to prevent division by zero errors
- **Updated model configurations**: Revised YAML configurations to reflect the new metrics structure with appropriate descriptions and metadata

### 📁 **Files Modified**
- Updates to models in `models/marts/` and `models/sources/` directories
- Configuration updates in various YAML files

### 🎯 **Benefits**
- **Simplified data model**: Easier to understand and maintain with fewer, more meaningful metrics
- **Improved reliability**: Division safety prevents runtime errors
- **Better user experience**: Unified ISH metric provides clearer insights into impression performance


**Version**: Bumped to 0.1.9 to reflect these improvements
